### PR TITLE
Change layer iteration to start from the first child

### DIFF
--- a/snowpyt/CAAMLv6_xml.py
+++ b/snowpyt/CAAMLv6_xml.py
@@ -212,7 +212,7 @@ def get_layers(path_xml, print2term=True):
     stratProfile = xmldoc.getElementsByTagName("caaml:stratProfile")
     if stratProfile.length > 0:
         Layers = []
-        for Layer in stratProfile[0].childNodes[3:]:
+        for Layer in stratProfile[0].childNodes[0:]:
             if Layer.nodeType not in {3, 8}:
                 lay = pc.layer()
                 for child in Layer.childNodes:


### PR DESCRIPTION
For me this seems to be a major bug, if i read in caaml files everytime the first three layers were missed.